### PR TITLE
feat: add get_subclasses tool to Brick server

### DIFF
--- a/rdf_mcp/servers/brick_server.py
+++ b/rdf_mcp/servers/brick_server.py
@@ -83,6 +83,20 @@ def get_subclasses(parent_class: str) -> list[str]:
 
 
 @mcp.tool()
+def get_brick_tags(term: str) -> list[str]:
+    """Get all tags associated with a Brick class or term"""
+    query = """
+    PREFIX brick: <https://brickschema.org/schema/Brick#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX tag: <https://brickschema.org/schema/BrickTag#>
+    SELECT DISTINCT ?tag WHERE {
+        ?term brick:hasAssociatedTag ?tag .
+    }"""
+    results = ontology.query(query, initBindings={"term": BRICK[term]})
+    return [str(row[0]).split("#")[-1] for row in results]
+
+
+@mcp.tool()
 def get_possible_properties(class_: str) -> list[tuple[str, str]]:
     """Returns pairs of possible (property, object type) for a given brick class"""
     query = """

--- a/rdf_mcp/servers/brick_server.py
+++ b/rdf_mcp/servers/brick_server.py
@@ -66,6 +66,23 @@ def get_properties() -> list[str]:
 
 
 @mcp.tool()
+def get_subclasses(parent_class: str) -> list[str]:
+    """Get all classes that inherit from a specific parent class in the Brick ontology"""
+    query = """
+    PREFIX owl: <http://www.w3.org/2002/07/owl#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX brick: <https://brickschema.org/schema/Brick#>
+    SELECT DISTINCT ?subclass WHERE {
+        ?subclass rdfs:subClassOf* ?parent .
+        ?subclass a owl:Class .
+        FILTER NOT EXISTS { ?subclass owl:deprecated true }
+        FILTER (?subclass != ?parent)
+    }"""
+    results = ontology.query(query, initBindings={"parent": BRICK[parent_class]})
+    return [str(row[0]).split("#")[-1] for row in results]
+
+
+@mcp.tool()
 def get_possible_properties(class_: str) -> list[tuple[str, str]]:
     """Returns pairs of possible (property, object type) for a given brick class"""
     query = """

--- a/rdf_mcp/utils/smash.py
+++ b/rdf_mcp/utils/smash.py
@@ -148,6 +148,7 @@ def smash_distance(
     # The final distance is in the bottom-right cell
     return d[n][m]
 
+
 # --- Example Usage (based on potential scenarios) ---
 
 # # Example 1: Typo + Abbreviation

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -185,3 +185,56 @@ def test_get_subclasses(mock_ontology):
     result = get_subclasses("LeafClass")
     assert isinstance(result, list)
     assert len(result) == 0
+
+
+@patch("rdf_mcp.servers.brick_server.ontology")
+def test_get_brick_tags(mock_ontology):
+    """Test get_brick_tags function."""
+    # Mock query results for tags of Zone_Air_Temperature_Sensor
+    mock_ontology.query.return_value = [
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/BrickTag#Zone"
+            ),
+        ),
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/BrickTag#Air"
+            ),
+        ),
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/BrickTag#Temperature"
+            ),
+        ),
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/BrickTag#Sensor"
+            ),
+        ),
+    ]
+    from rdf_mcp.servers.brick_server import get_brick_tags
+
+    result = get_brick_tags("Zone_Air_Temperature_Sensor")
+
+    # Verify it's a list
+    assert isinstance(result, list)
+
+    # Verify it contains expected tags
+    assert "Zone" in result
+    assert "Air" in result
+    assert "Temperature" in result
+    assert "Sensor" in result
+
+    # Verify the term was passed correctly in the query
+    mock_ontology.query.assert_called_once()
+    call_args = mock_ontology.query.call_args
+    assert "term" in call_args.kwargs.get("initBindings", {})
+
+    # Test with a class that has no tags
+    mock_ontology.reset_mock()
+    mock_ontology.query.return_value = []
+
+    result = get_brick_tags("ClassWithoutTags")
+    assert isinstance(result, list)
+    assert len(result) == 0

--- a/tests/test_brick.py
+++ b/tests/test_brick.py
@@ -126,3 +126,62 @@ def test_get_properties(mock_ontology):
     assert "hasPart" in result
     assert "area" in result
     assert "value" in result
+
+
+@patch("rdf_mcp.servers.brick_server.ontology")
+def test_get_subclasses(mock_ontology):
+    """Test get_subclasses function."""
+    # Mock query results for subclasses of Sensor
+    mock_ontology.query.return_value = [
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/Brick#Temperature_Sensor"
+            ),
+        ),
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/Brick#Air_Temperature_Sensor"
+            ),
+        ),
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/Brick#Zone_Air_Temperature_Sensor"
+            ),
+        ),
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/Brick#CO2_Sensor"
+            ),
+        ),
+        (
+            MagicMock(
+                __str__=lambda self: "https://brickschema.org/schema/Brick#Humidity_Sensor"
+            ),
+        ),
+    ]
+    from rdf_mcp.servers.brick_server import get_subclasses
+
+    result = get_subclasses("Sensor")
+
+    # Verify it's a list
+    assert isinstance(result, list)
+
+    # Verify it contains expected subclasses
+    assert "Temperature_Sensor" in result
+    assert "Air_Temperature_Sensor" in result
+    assert "Zone_Air_Temperature_Sensor" in result
+    assert "CO2_Sensor" in result
+    assert "Humidity_Sensor" in result
+
+    # Verify the parent class was passed correctly in the query
+    mock_ontology.query.assert_called_once()
+    call_args = mock_ontology.query.call_args
+    assert "parent" in call_args.kwargs.get("initBindings", {})
+
+    # Test with a class that has no subclasses
+    mock_ontology.reset_mock()
+    mock_ontology.query.return_value = []
+
+    result = get_subclasses("LeafClass")
+    assert isinstance(result, list)
+    assert len(result) == 0


### PR DESCRIPTION
Add new MCP tool to retrieve all classes that inherit from a specific parent class in the Brick ontology. Uses SPARQL with transitive rdfs:subClassOf to get both direct and nested descendants.

- Add get_subclasses function with SPARQL query
- Include test coverage for the new tool
- Format code with black